### PR TITLE
feat: introduce mutex locking to avoid race conditions that lead to transaction failures

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -7,6 +7,7 @@
     "serve": "npm run build && firebase emulators:start --only functions",
     "shell": "npm run build && firebase functions:shell",
     "start": "npm run shell",
+    "emulate": "firebase emulators:start --import=exported-dev-data --export-on-exit=exported-dev-data",
     "deploy": "firebase deploy --only functions",
     "logs": "firebase functions:log"
   },

--- a/functions/package.json
+++ b/functions/package.json
@@ -12,7 +12,7 @@
     "logs": "firebase functions:log"
   },
   "engines": {
-    "node": "16"
+    "node": "18"
   },
   "main": "lib/src/index.js",
   "dependencies": {

--- a/functions/src/controllers/AnnounceController.ts
+++ b/functions/src/controllers/AnnounceController.ts
@@ -73,6 +73,7 @@ export class AnnounceController extends AbstractController {
       res: Response,
       next: NextFunction): Promise<void> {
     const newdHealthService = NewdHealthService.getInstance();
+    const firestoreService = FirestoreService.getInstance();
     const {data} = req.body;
     const authorizationKey = req.headers.authorization;
     if (!authorizationKey) {
@@ -109,17 +110,46 @@ export class AnnounceController extends AbstractController {
       }
       const recipientAddress = senderEntity?.production ?
         recipientConfig.production : recipientConfig.staging;
-      const result = await newdHealthService.sendTokens(
-          senderMnemonic,
-          recipientAddress,
-          [
-            {
-              denom: "udhp",
-              amount: "1",
-            },
-          ],
-          JSON.stringify(data)
-      );
+
+      // Send tokens synchronously across instances using Mutex locking
+      let retries = 0;
+      const sendTokens: any = async () => {
+        try {
+          // acquire lock
+          await firestoreService.acquireLock(`locks/${authorizationKey}`);
+          // process synchronously
+          const result = await newdHealthService.sendTokens(
+              senderMnemonic,
+              recipientAddress,
+              [
+                {
+                  denom: "udhp",
+                  amount: "1",
+                },
+              ],
+              JSON.stringify(data)
+          );
+          // release lock
+          await firestoreService.releaseLock(`locks/${authorizationKey}`);
+          // return result
+          return result;
+        } catch (err: any) {
+          // retry
+          if (retries > 100) throw err;
+          retries++;
+          await sleep(1000);
+          return await sendTokens();
+        }
+      }
+
+      const sleep = async (ms: number) => {
+        return new Promise((resolve) => {
+          setTimeout(resolve, ms);
+        });
+      }
+
+      const result = await sendTokens();
+
       ResponseService
           .getInstance()
           .sendResponse(res, 200, {transactionHash: result.transactionHash});

--- a/functions/src/controllers/AnnounceController.ts
+++ b/functions/src/controllers/AnnounceController.ts
@@ -135,7 +135,7 @@ export class AnnounceController extends AbstractController {
           return result;
         } catch (err: any) {
           // retry
-          if (retries > 100) throw err;
+          if (retries > 200) throw err;
           retries++;
           await sleep(1000);
           return await sendTokens();

--- a/functions/src/controllers/AnnounceController.ts
+++ b/functions/src/controllers/AnnounceController.ts
@@ -10,6 +10,7 @@
 import {Request, Response, NextFunction} from "express";
 import {Account, Address} from "@dhealth/sdk";
 import {DocumentData} from "firebase-admin/firestore";
+import {DeliverTxResponse} from "@cosmjs/stargate";
 
 // internal dependencies
 import {AbstractController} from "./AbstractController";
@@ -113,7 +114,7 @@ export class AnnounceController extends AbstractController {
 
       // Send tokens synchronously across instances using Mutex locking
       let retries = 0;
-      const sendTokens: any = async () => {
+      const sendTokens: () => Promise<DeliverTxResponse> = async () => {
         try {
           // acquire lock
           await firestoreService.acquireLock(`locks/${authorizationKey}`);
@@ -133,28 +134,28 @@ export class AnnounceController extends AbstractController {
           await firestoreService.releaseLock(`locks/${authorizationKey}`);
           // return result
           return result;
-        } catch (err: any) {
+        } catch (err) {
           // retry
           if (retries > 200) throw err;
           retries++;
           await sleep(1000);
           return await sendTokens();
         }
-      }
+      };
 
       const sleep = async (ms: number) => {
         return new Promise((resolve) => {
           setTimeout(resolve, ms);
         });
-      }
+      };
 
       const result = await sendTokens();
 
       ResponseService
           .getInstance()
           .sendResponse(res, 200, {transactionHash: result.transactionHash});
-    } catch (err: any) {
-      next(err.stack);
+    } catch (err) {
+      if (err instanceof Error) next(err.stack);
     }
   }
 
@@ -207,8 +208,8 @@ export class AnnounceController extends AbstractController {
           data
       );
       ResponseService.getInstance().sendResponse(res, 200, result);
-    } catch (err: any) {
-      next(err.stack);
+    } catch (err) {
+      if (err instanceof Error) next(err.stack);
     }
   }
 }

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -41,4 +41,4 @@ const initApp = async (req: Request, res: Response) => {
 };
 
 // Expose Express API as a single Cloud Function:
-export const dtps = onRequest(initApp);
+export const dtps = onRequest({ timeoutSeconds: 300 }, initApp);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -32,6 +32,15 @@ const initApp = async (req: Request, res: Response) => {
   app.use("/", RootController.getInstance().controller);
   app.use("/announce", AnnounceController.getInstance().controller);
 
+  // Invalid routes
+  app.use((req: Request, res: Response) => {
+    res.status(404).json({
+      message: `Cannot ${req.method} ${req.path}`,
+      error: "Not Found",
+      statusCode: 404
+    });
+  });
+
   // Add error handler
   app.use((err: object, req: Request, res: Response) => {
     ResponseService.getInstance().sendResponse(res, 500, "Server error", err);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -33,7 +33,7 @@ const initApp = async (req: Request, res: Response) => {
   app.use("/announce", AnnounceController.getInstance().controller);
 
   // Add error handler
-  app.use((err: any, req: Request, res: Response) => {
+  app.use((err: object, req: Request, res: Response) => {
     ResponseService.getInstance().sendResponse(res, 500, "Server error", err);
   });
 
@@ -41,4 +41,4 @@ const initApp = async (req: Request, res: Response) => {
 };
 
 // Expose Express API as a single Cloud Function:
-export const dtps = onRequest({ timeoutSeconds: 300 }, initApp);
+export const dtps = onRequest({timeoutSeconds: 300}, initApp);

--- a/functions/src/services/FirestoreService.ts
+++ b/functions/src/services/FirestoreService.ts
@@ -8,7 +8,15 @@
  */
 // external dependencies
 import {initializeApp} from "firebase-admin/app";
-import {getFirestore, Firestore, DocumentData} from "firebase-admin/firestore";
+import {
+  getFirestore,
+  Firestore,
+  DocumentData,
+  WhereFilterOp,
+  Query,
+  QuerySnapshot,
+  WriteResult
+} from "firebase-admin/firestore";
 
 /**
  * @class FirestoreService
@@ -76,5 +84,111 @@ export class FirestoreService {
     } else {
       return doc.data();
     }
+  }
+
+  /**
+   * Add document to collection.
+   *
+   * @access public
+   * @async
+   * @param {string} collection
+   * @param {Record<string, any>} data
+   * @return {string}
+   */
+  public async addDoc(
+    collection: string,
+    data: Record<string, any>
+  ): Promise<string> {
+    const docRef = this.db.collection(collection).doc();
+    await docRef.set(data);
+    return docRef.id;
+  }
+
+  /**
+   * Update document in collection.
+   *
+   * @access public
+   * @async
+   * @param {string} collection
+   * @param {string} id
+   * @param {Record<string, any>} data
+   * @return {Promise<FirebaseFirestore.WriteResult>}
+   */
+  public async updateDoc(
+    collection: string,
+    id: string,
+    data: Record<string, any>
+  ): Promise<FirebaseFirestore.WriteResult> {
+    const docRef = this.db.collection(collection).doc(id);
+    const result = await docRef.update(data);
+    return result;
+  }
+
+  /**
+   * Query document in collection.
+   *
+   * @access public
+   * @async
+   * @param {string} collection
+   * @param {string} fieldPath
+   * @param {WhereFilterOp} opString
+   * @param {any} value
+   * @param {string} orderBy
+   * @param {number} limit
+   * @return {Promise<QuerySnapshot<DocumentData>>}
+   */
+  public async queryDoc(
+    collection: string,
+    fieldPath: string,
+    opString: WhereFilterOp,
+    value: any,
+    orderBy?: string,
+    limit?: number
+  ): Promise<QuerySnapshot<DocumentData>> {
+    let docRef: Query<DocumentData> = this.db.collection(collection);
+    if (fieldPath !== null && opString != null && value != null) {
+      docRef = docRef.where(fieldPath, opString, value);
+    }
+    if (orderBy) {
+      docRef = docRef.orderBy(orderBy);
+    }
+    if (limit) {
+      docRef = docRef.limit(limit);
+    }
+    return await docRef.get();
+  }
+
+  /**
+   * Acquire a lock for a document.
+   *
+   * @access public
+   * @async
+   * @param {string} lockPath
+   * @return {Promise<FirebaseFirestore.WriteResult>}
+   */
+  public async acquireLock(lockPath: string): Promise<FirebaseFirestore.WriteResult> {
+    const lockDoc = this.db.doc(lockPath);
+    const now = Date.now();
+
+    // Try to acquire the lock
+    const lock = await lockDoc.get();
+    if (lock.exists && lock.data()?.expiresAt > now) {
+      throw new Error("Lock is already held");
+    }
+
+    // Set the lock
+    return await lockDoc.set({ expiresAt: now + 10000 }); // Lock expires in 10 seconds
+  }
+
+  /**
+   * Release lock for a document.
+   *
+   * @access public
+   * @async
+   * @param {string} lockPath
+   * @return {Promise<WriteResult>}
+   */
+  public async releaseLock(lockPath: string): Promise<WriteResult> {
+    return await this.db.doc(lockPath).delete();
   }
 }

--- a/functions/src/services/FirestoreService.ts
+++ b/functions/src/services/FirestoreService.ts
@@ -15,7 +15,7 @@ import {
   WhereFilterOp,
   Query,
   QuerySnapshot,
-  WriteResult
+  WriteResult,
 } from "firebase-admin/firestore";
 
 /**
@@ -92,12 +92,12 @@ export class FirestoreService {
    * @access public
    * @async
    * @param {string} collection
-   * @param {Record<string, any>} data
+   * @param {Record<string, unknown>} data
    * @return {string}
    */
   public async addDoc(
-    collection: string,
-    data: Record<string, any>
+      collection: string,
+      data: Record<string, unknown>
   ): Promise<string> {
     const docRef = this.db.collection(collection).doc();
     await docRef.set(data);
@@ -111,13 +111,13 @@ export class FirestoreService {
    * @async
    * @param {string} collection
    * @param {string} id
-   * @param {Record<string, any>} data
+   * @param {Record<string, unknown>} data
    * @return {Promise<FirebaseFirestore.WriteResult>}
    */
   public async updateDoc(
-    collection: string,
-    id: string,
-    data: Record<string, any>
+      collection: string,
+      id: string,
+      data: Record<string, unknown>
   ): Promise<FirebaseFirestore.WriteResult> {
     const docRef = this.db.collection(collection).doc(id);
     const result = await docRef.update(data);
@@ -132,18 +132,18 @@ export class FirestoreService {
    * @param {string} collection
    * @param {string} fieldPath
    * @param {WhereFilterOp} opString
-   * @param {any} value
+   * @param {unknown} value
    * @param {string} orderBy
    * @param {number} limit
    * @return {Promise<QuerySnapshot<DocumentData>>}
    */
   public async queryDoc(
-    collection: string,
-    fieldPath: string,
-    opString: WhereFilterOp,
-    value: any,
-    orderBy?: string,
-    limit?: number
+      collection: string,
+      fieldPath: string,
+      opString: WhereFilterOp,
+      value: unknown,
+      orderBy?: string,
+      limit?: number
   ): Promise<QuerySnapshot<DocumentData>> {
     let docRef: Query<DocumentData> = this.db.collection(collection);
     if (fieldPath !== null && opString != null && value != null) {
@@ -166,7 +166,9 @@ export class FirestoreService {
    * @param {string} lockPath
    * @return {Promise<FirebaseFirestore.WriteResult>}
    */
-  public async acquireLock(lockPath: string): Promise<FirebaseFirestore.WriteResult> {
+  public async acquireLock(
+      lockPath: string
+  ): Promise<FirebaseFirestore.WriteResult> {
     const lockDoc = this.db.doc(lockPath);
     const now = Date.now();
 
@@ -177,7 +179,9 @@ export class FirestoreService {
     }
 
     // Set the lock
-    return await lockDoc.set({ expiresAt: now + 10000 }); // Lock expires in 10 seconds
+    return await lockDoc.set({
+      expiresAt: now + 10000,
+    }); // Lock expires in 10 seconds
   }
 
   /**

--- a/functions/src/services/HttpRequestHandler.ts
+++ b/functions/src/services/HttpRequestHandler.ts
@@ -65,10 +65,10 @@ export class HttpRequestHandler {
    * @async
    * @param   {string}   url
    * @param   {string}   method
-   * @param   {any}      body
-   * @param   {any}      options
-   * @param   {any}      headers
-   * @return {Promise<AxiosResponse<any, any>>}
+   * @param   {object}      body
+   * @param   {object}      options
+   * @param   {object}      headers
+   * @return {Promise<AxiosResponse<{data: object}>>}
    */
   public async call(
       url: string,
@@ -76,7 +76,7 @@ export class HttpRequestHandler {
       body: object = {},
       options: object = {},
       headers: object = {},
-  ): Promise<AxiosResponse<any, any>> {
+  ): Promise<AxiosResponse<{data: object}>> {
     // POST requests are supported
     if (method === "POST") {
       return axios.post(url, body, {

--- a/functions/src/services/NetworkService.ts
+++ b/functions/src/services/NetworkService.ts
@@ -115,9 +115,10 @@ export class NetworkService {
    *
    * @access public
    * @async
-   * @return {Promise<Record<string, any>>}
+   * @return {Promise<Record<string, object>>}
    */
-  public async connectToAnAvailableNode(): Promise<Record<string, any>> {
+  public async connectToAnAvailableNode()
+    : Promise<Record<string, object>> {
     // prepares the connection parameters
     const nodeUrl = await this.getNextAvailableNode();
     const node = this.connectToNode(nodeUrl);
@@ -182,11 +183,11 @@ export class NetworkService {
    *
    * @access protected
    * @param {string} nodeUrl
-   * @return {Record<string, any>}
+   * @return {Record<string, object>}
    */
   protected connectToNode(
       nodeUrl: string,
-  ): Record<string, any> {
+  ): Record<string, object> {
     // configures the repository factory
     const repositoryFactoryHttp = new RepositoryFactoryHttp(nodeUrl, {
       generationHash: this.GENERATION_HASH,

--- a/functions/src/services/ResponseService.ts
+++ b/functions/src/services/ResponseService.ts
@@ -58,14 +58,14 @@ export class ResponseService {
    * @param {Response} res
    * @param {number} statusCode
    * @param {string | object} content
-   * @param {any} error
+   * @param {object} error
    * @return {void}
    */
   public sendResponse(
       res: Response,
       statusCode: number,
       content: string | object,
-      error?: any
+      error?: object
   ): void {
     res.locals.responseContent = content;
     res.locals.error = error;

--- a/functions/src/services/dHealthService.ts
+++ b/functions/src/services/dHealthService.ts
@@ -15,6 +15,7 @@ import {
   SignedTransaction,
   Transaction,
   TransactionAnnounceResponse,
+  TransactionRepository,
   TransferTransaction,
   UInt64,
 } from "@dhealth/sdk";
@@ -148,7 +149,7 @@ export class DhealthService {
   ): Promise<TransactionAnnounceResponse> {
     const networkService = NetworkService.getInstance();
     const node = await networkService.connectToAnAvailableNode();
-    const transactionHttp = node.transactionRepository;
+    const transactionHttp = node.transactionRepository as TransactionRepository;
     const response = transactionHttp.announce(signedTransaction);
     return response.toPromise();
   }


### PR DESCRIPTION
- Account based blockchains have sequential transaction processing. This creates race conditions when sending transactions simultaneously.
- Add mutex locking for each authorized account.
- Each request that invokes an authorized account will start a lock and subsequent requests wait.